### PR TITLE
BugFix: Disable Providers not working for Arg Parsing

### DIFF
--- a/itsybitsy/itsybitsy.py
+++ b/itsybitsy/itsybitsy.py
@@ -1,7 +1,7 @@
 # Copyright # Copyright 2020 Life360, Inc
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 import asyncio
 import configargparse

--- a/itsybitsy/providers.py
+++ b/itsybitsy/providers.py
@@ -89,7 +89,7 @@ _provider_registry = PluginFamilyRegistry(ProviderInterface)
 
 
 def parse_provider_args(argparser: configargparse.ArgParser):
-    _provider_registry.parse_plugin_args(argparser)
+    _provider_registry.parse_plugin_args(argparser, constants.ARGS.disable_providers)
 
 
 def register_providers():


### PR DESCRIPTION
### 

Previously, even through you would pass in, for example `--disable-providers=k8s`... itsy would still error out during arg parsing, expecting the `provider_k8s.py` plugin required arguments to be present!

This solution is short term, will write up a long term solution with an appropriate refactor.